### PR TITLE
add zip to release task

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#QuickVis
+# QuickVis
 QuickVis is a graphing library with the goal of visualizing data in a way that is fast and easy to read. The visualizations are minimally interactive, not pan or zoomable, and do not refresh themselves. You put some data in and you get a visualization. END!
 
 ![some quickvis vis's](quickvis1.png)
@@ -48,14 +48,66 @@ make test
 make release
 ```
 
-## Development Best Practices
+## Releasing
+Use git flow to release a version to the `master` branch. A jenkins job can be triggered manually to build and publish the
+artifact to zenpip.  During the git flow release process, update the version in the makefile by removing the `dev`
+suffix and then increment the version number in the `develop` branch.
 
+### Versioning
+The version convention is for the `develop` branch to have the next release version, a number higher than what is
+ currently released, with the `-dev` suffix. The `master` branch will have the currently released version.  For
+ example, if the currently released version is `1.1.0` the version in the `develop` will be `1.1.1-dev`,
+
+### Release Steps
+1. Check out the `master` branch and make sure to have latest `master`.
+  * `git checkout master`
+  * `git pull origin master`
+
+2. Check out the `develop` branch.
+  * `git checkout develop`
+  * `git pull origin develop`
+
+3. Start release of next version. The version is usually the version in the makefile minus the `-dev` suffix.  e.g., if the version
+  in `develop` is `1.1.1-dev` and in `master` `1.1.0`, then the
+  `<release_name>` will be the new version in `master`, i.e. `1.1.1`.
+  *  `git flow release start <release_name>`
+
+4. Update the `VERSION` variable in the make file. e.g set it to `1.1.1`
+
+5. run `make` to make sure everything builds properly.
+
+6. Commit and tag everything, don't push.
+  * `git commit....`
+  * `git flow release finish <release_name>`
+  * `git push origin --tags`
+
+7. You will be on the `develop` branch again. While on `develop` branch, edit the the `VERSION` variable in the makefile to
+be the next development version. For example, if you just released version 1.1.1, then change the `VERSION` variable to
+`1.1.2-dev`.
+
+8. Check in `develop` version bump and push.
+  * `git commit...`
+  * `git push`
+
+9. Push the `master` branch which should have the new released version.
+  * `git checkout master`
+  * `git push`
+
+10. Have someone manually kick off the jenkins job to build master which will publish the images to Docker hub.
+
+## Development Best Practices
 The pieces at play here are the usual supects: **Model**, **View**, and **ViewModel**. **Model** is whatever data is passed by the user into the `update()` function, and should be treated as immutable. **View** is the HTML template that is eventually passed into the DOM. The **ViewModel** is the instance of the visualization (eg: Sparkline or StackedBar), and contains the model as well as template helper methods for getting human-readable info from the model. In this way, the ViewModel binds the View together with the Model.
 
 In order to keep things as reasonable as one can expect in the wild west of webdev, there are some best practices that should be followed when creating new visualizations or modifying existing ones. Take a look at `src/Sparkline.js` for lots of comments about the module's structure.
 
 * Only touch the DOM in the `_render()` method or draw helper methods, but no where else! The DOM is dangerous and scary and should be hidden far far away. However, to keep `_render()` from getting to unwieldy, you can create draw helpers to do specific things like `drawLine()`. It's ok to access the DOM inside helpers as well, but treat the DOM like some sort of terrifying mystical creature that you don't really understand because it basically is.
 
+[TODO - sample code]
+
 * Keep templates as logic-less as possible. If you want to do any logic, write a helper method. Template helper methods have the task of taking obtuse model data, like `1467038751`, and turning it into something a human can use, such as "Mon, 27 Jun 2016 14:45:51 GMT". Prefer tiny little helpers that do one little thing and compose them together to take imcomprehensible model data and turn it into useful visualization.
 
+[TODO - sample code]
+
 * Don't modify the model. If you need to generate something new from the model data (like taking the average of an array of numbers), do it inside the `_update()` method, and attach the newly generated info to the viewmodel (aka `this`). If the new data is purely for presentation (like converting a timestamp to date), then it belongs in a template helper, not on the viewmodel.
+
+[TODO - sample code]

--- a/gulp/injectcss.js
+++ b/gulp/injectcss.js
@@ -41,7 +41,6 @@ function injectCSS(dest){
                 cb(err);
             });
         });
-       cb();
     };
 
     let endStream = function(cb){

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,8 @@
 
 var gulp = require("gulp"),
     sequence = require("gulp-sequence"),
-    clean = require("gulp-clean");
+    clean = require("gulp-clean"),
+    zip = require("gulp-zip");
 
 let {paths, srcSubdirectories} = require("./gulp/config");
 
@@ -27,7 +28,7 @@ gulp.task("dist", function(cb){
 // build js bundle and run tests
 gulp.task("release", function(callback){
     // TODO - increment version number?
-    sequence("dist", "test")(callback);
+    sequence("clean", "zip", "test")(callback);
 });
 
 gulp.task("clean", function(){
@@ -36,6 +37,15 @@ gulp.task("clean", function(){
             paths.www
         ])
         .pipe(clean());
+});
+
+gulp.task("zip", ["dist"], function(){
+    return gulp.src([
+            paths.build + paths.versionedQuickVis,
+            paths.build + paths.versionedQuickVis + ".map"
+        ])
+        .pipe(zip(paths.versionedQuickVis.replace(".js", ".zip")))
+        .pipe(gulp.dest(paths.build));
 });
 
 // build the demo page/app

--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ build: npm-install
 		-e UID_X=$(UID) \
 		-e GID_X=$(GID) \
 		$(TAG) \
-		/bin/bash -c "source /root/userdo.sh \"cd $(docker_working_DIR) && gulp dist\""; \
+		/bin/bash -c "source /root/userdo.sh \"cd $(docker_working_DIR) && gulp dist\"";
 
 # test the quickvis lib
 test: npm-install
@@ -26,7 +26,7 @@ test: npm-install
 		-e UID_X=$(UID) \
 		-e GID_X=$(GID) \
 		$(TAG) \
-		/bin/bash -c "source /root/userdo.sh \"cd $(docker_working_DIR) && gulp test\""; \
+		/bin/bash -c "source /root/userdo.sh \"cd $(docker_working_DIR) && gulp test\"";
 
 # build, zip, test quickvis lib
 release: npm-install
@@ -35,7 +35,7 @@ release: npm-install
 		-e UID_X=$(UID) \
 		-e GID_X=$(GID) \
 		$(TAG) \
-		/bin/bash -c "source /root/userdo.sh \"cd $(docker_working_DIR) && gulp release\""; \
+		/bin/bash -c "source /root/userdo.sh \"cd $(docker_working_DIR) && gulp release\"";
 
 # install npm packages
 npm-install:
@@ -44,6 +44,6 @@ npm-install:
 		-e UID_X=$(UID) \
 		-e GID_X=$(GID) \
 		$(TAG) \
-		/bin/bash -c "source /root/userdo.sh \"cd $(docker_working_DIR) && npm install\""; \
+		/bin/bash -c "source /root/userdo.sh \"cd $(docker_working_DIR) && npm install\"";
 
 .PHONY: default build test release npm-install

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-sequence": "~0.4.1",
     "gulp-sourcemaps": "~1.6.0",
+    "gulp-zip": "^3.2.0",
     "jasmine": "^2.4.1",
     "karma": "^1.1.0",
     "karma-chrome-launcher": "^1.0.1",


### PR DESCRIPTION
This adds zip file creation to `gulp release`. Also adds release instructions to bump master. Once this is in place, the instructions can be followed and the jenkins release job kicked off to bump master and push the zip to zenpip.